### PR TITLE
fix: fix "text file busy"

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -72,16 +72,6 @@ func Run(ldflags *LDFlags) error {
 	}
 
 	log.Println("[INFO] Installing aqua")
-	aquaFile, err := os.CreateTemp("", "aqua")
-	if err != nil {
-		return fmt.Errorf("create a temporal file to install aqua: %w", err)
-	}
-	defer aquaFile.Close()
-	param.AquaInstallPath = aquaFile.Name()
-	if err := os.Chmod(param.AquaInstallPath, binPermission); err != nil {
-		return fmt.Errorf("change aqua's file permission: %w", err)
-	}
-
 	if err := installAqua(ctx, param); err != nil {
 		return fmt.Errorf("install aqua: %w", err)
 	}
@@ -127,6 +117,16 @@ func copyFile(ctx context.Context, aquaInstallPath, dest, bin string) error {
 }
 
 func installAqua(ctx context.Context, param *Param) error {
+	aquaFile, err := os.CreateTemp("", "aqua")
+	if err != nil {
+		return fmt.Errorf("create a temporal file to install aqua: %w", err)
+	}
+	defer aquaFile.Close()
+	param.AquaInstallPath = aquaFile.Name()
+	if err := os.Chmod(param.AquaInstallPath, binPermission); err != nil {
+		return fmt.Errorf("change aqua's file permission: %w", err)
+	}
+
 	u := fmt.Sprintf("https://github.com/aquaproj/aqua/releases/%s/download/aqua_%s_%s.tar.gz", param.AquaVersion, runtime.GOOS, runtime.GOARCH)
 	log.Printf("Downloading %s", u)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)

--- a/pkg/api/unarchive.go
+++ b/pkg/api/unarchive.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 )
 
 const maxFileSize = 1073741824 // 1GB
@@ -31,7 +30,6 @@ func unarchive(dest io.Writer, src io.Reader) error {
 		if err != nil {
 			return fmt.Errorf("read a tarball: %w", err)
 		}
-		log.Printf("[DEBUG] hdr.Name: %s", hdr.Name)
 		if hdr.Name != "aqua" {
 			continue
 		}


### PR DESCRIPTION
```
+ /tmp/aqua1876745684 -c aqua.yaml i
2022/07/05 00:14:29 aqua i: execute a command: /tmp/aqua1876745684 -c aqua.yaml i: fork/exec /tmp/aqua1876745684: text file busy
exit status 1
```